### PR TITLE
Small PowerPoint generation corrections

### DIFF
--- a/src/powerpointgenerator/PolicyViews/ConditionClientAppTypes.cs
+++ b/src/powerpointgenerator/PolicyViews/ConditionClientAppTypes.cs
@@ -20,7 +20,7 @@ public class ConditionClientAppTypes : PolicyView
             if (clientAppType == ConditionalAccessClientApp.All) { return string.Empty; } //CA blade shows "All" as 'Not configured' so we do the same and hide it in the doc
             if (clientAppType == ConditionalAccessClientApp.Browser) { AppendName(sb, "Browser"); }
             if (clientAppType == ConditionalAccessClientApp.MobileAppsAndDesktopClients) { AppendName(sb, "Mobile app and desktop clients"); }
-            if (clientAppType == ConditionalAccessClientApp.ExchangeActiveSync || clientAppType == ConditionalAccessClientApp.EasSupported) { AppendName(sb, " Exchange ActiveSync clients"); }
+            if (clientAppType == ConditionalAccessClientApp.ExchangeActiveSync || clientAppType == ConditionalAccessClientApp.EasSupported) { AppendName(sb, "Exchange ActiveSync clients"); }
             if (clientAppType == ConditionalAccessClientApp.Other) { AppendName(sb, "Other legacy clients"); }
         }
 

--- a/src/powerpointgenerator/PolicyViews/ConditionRisks.cs
+++ b/src/powerpointgenerator/PolicyViews/ConditionRisks.cs
@@ -16,7 +16,7 @@ public class ConditionRisks : PolicyView
     {
         var sb = new StringBuilder();
 
-        AppendRisk(sb, Policy.Conditions.UserRiskLevels, "User risk risk:");
+        AppendRisk(sb, Policy.Conditions.UserRiskLevels, "User risk:");
         AppendRisk(sb, Policy.Conditions.SignInRiskLevels, "Sign-in risk:");
         AppendRisk(sb, Policy.Conditions.ServicePrincipalRiskLevels, "Service principal risk:");
 

--- a/src/powerpointgenerator/PowerPointHelper.cs
+++ b/src/powerpointgenerator/PowerPointHelper.cs
@@ -38,7 +38,7 @@ public class PowerPointHelper
             {
                 var para = textBody.AddParagraph(line);
                 para.Font.FontSize = 11;
-                if (line.IndexOf("-") < 0)
+                if (!line.StartsWith("-"))
                 {
                     para.Font.Bold = true;
                 }


### PR DESCRIPTION
Hello,

Mainly small corrections
- Removed duplicate term risk ("User risk risk" => "User risk")
- Updated text bold formatting logic to check for <starting with "-"> instead of <containing "-">
- Removed leading space in Client App Type "Exchange ActiveSync clients"

Thanks, have an excellent day, kind regards,
Fabrice

PS: Those changes haven't been tested/validated